### PR TITLE
GKE Lecture Update required on deployment with resources

### DIFF
--- a/k8s-specifications/db-deployment.yaml
+++ b/k8s-specifications/db-deployment.yaml
@@ -28,6 +28,13 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/postgresql/data
           name: db-data
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
       volumes:
       - name: db-data
         emptyDir: {} 

--- a/k8s-specifications/redis-deployment.yaml
+++ b/k8s-specifications/redis-deployment.yaml
@@ -23,6 +23,14 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: redis-data
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
       volumes:
       - name: redis-data
         emptyDir: {} 
+

--- a/k8s-specifications/result-deployment.yaml
+++ b/k8s-specifications/result-deployment.yaml
@@ -20,3 +20,11 @@ spec:
         ports:
         - containerPort: 80
           name: result
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+            

--- a/k8s-specifications/vote-deployment.yaml
+++ b/k8s-specifications/vote-deployment.yaml
@@ -20,3 +20,10 @@ spec:
         ports:
         - containerPort: 80
           name: vote
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"

--- a/k8s-specifications/worker-deployment.yaml
+++ b/k8s-specifications/worker-deployment.yaml
@@ -17,3 +17,10 @@ spec:
       containers:
       - image: dockersamples/examplevotingapp_worker
         name: worker
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+        limits:
+          cpu: "500m"
+          memory: "512Mi"


### PR DESCRIPTION
Hi,
Reference:
1. **Course:** Kubernetes for the Absolute Beginners - Hands-on](https://www.udemy.com/course/learn-kubernetes/)
2. **Lecture 54**: GKE default settings requires you to set up the resources in the containers, if you don't do that declaratively, then the Autopilot injects the default resources which may restrict you from deploying additional resources.

Problem:
1. If you try to create resources out of deployment yaml files without defining resources (cpu + memory), then it will give you the following error on your GKE CLI:
_Warning: autopilot-default-resources-mutator:Autopilot updated Deployment default/result: defaulted unspecified 'cpu' resource for containers [result] (see http://g.co/gke/autopilot-defaults)._

Solution:
1. Define resource requests + Limits in all your pods specs.
3. Then create resources, and all your pods will run.
Reference link of Autopilot: https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-resource-requests#defaults
